### PR TITLE
Use click for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,144 +1,138 @@
-# :construction: pypfb :construction:
+# :construction: PFB Python SDK :construction:
 
-Python SDK to create, explore and modify PFB files.
+Python SDK to create, explore and modify PFB (Portable Format for Biomedical Data) files.
 
 ## PFB Schema
 
 [![metadata][1]][1]
 
+## Installation
+
+* From PyPI:
+
+```bash
+pip install pypfb[gen3]
+```
+
+(The optional `gen3` dependencies add the ability to convert a Gen3 data dictionary into
+a PFB file.)
+
+* From source code:
+
+```bash
+pipenv install
+```
+
+(Also add `--dev` for development.)
+
+
 ## Usage
 
 ### Main
 
-    usage: pypfb [-h] {show,dict2pfb,json2pfb,make,rename} ...
-    
-    PFB tool
-    
-    positional arguments:
-      {show,dict2pfb,json2pfb,make,rename}
-        show                Show schema or records of the PFB file
-        dict2pfb            Convert datadictionary into PFB file with schema
-        json2pfb            Convert JSON files correspond to datadictionary into
-                            PFB file
-        make                Make blank record
-        rename              Rename different parts of schema
-    
-    optional arguments:
-      -h, --help            show this help message and exit
+    Usage: pfb [OPTIONS] COMMAND [ARGS]...
+
+      PFB: Portable Format for Biomedical Data.
+
+    Commands:
+      add     Add a record from a minified JSON file to the PFB file.
+      from    Generate PFB from other data formats.
+      make    Make blank record from the PFB file.
+      rename  Rename different parts of schema.
+      show    Show schema or records of the PFB file.
 
 ### Show different parts of PFB
 
-    usage: pypfb show [-h] [-s] [--limit LIMIT] input
-    
-    positional arguments:
-      input          Path to PFB file
-    
-    optional arguments:
-      -h, --help     show this help message and exit
-      -s, --schema   Show PFB file schema
-      --limit LIMIT  How many entries to show, -1 for all; ignored for "schema"
+    Usage: pfb show [OPTIONS] PFB
 
-### Convert datadictionary into PFB schema
+      Show schema or records of the PFB file.
 
-    usage: pypfb dict2pfb [-h] -d DICTIONARY -o OUTPUT
-    
-    optional arguments:
-      -h, --help            show this help message and exit
-      -d DICTIONARY, --dictionary DICTIONARY
-                            Link to dictionary URL
-      -o OUTPUT, --output OUTPUT
-                            Output PFB file
+    Options:
+      -s, --schema     Show PFB file schema.
+      --limit INTEGER  How many entries to show, -1 for all; ignored for "schema".
+
+### Convert Gen3 data dictionary into PFB schema
+
+    Usage: pfb from dict [OPTIONS] URL
+
+      Convert Gen3 data dictionary at URL into PFB file.
+
+    Options:
+      -o, --output FILENAME  Output PFB file.  [required]
 
 ### Convert JSON for corresponding datadictionary to PFB
 
-    usage: pypfb json2pfb [-h] -s SCHEMA -o OUTPUT --program PROGRAM
-                                --project PROJECT
-                                dir
-    
-    positional arguments:
-      dir                   Path to directory with input JSON files
-    
-    optional arguments:
-      -h, --help            show this help message and exit
-      -s SCHEMA, --schema PFB SCHEMA
-                            Filename for schema PFB file
-      -o OUTPUT, --output OUTPUT
-                            Filename for resulting PFB file
-      --program PROGRAM     Name of the program
-      --project PROJECT     Name of the project
+    Usage: pfb from json [OPTIONS] PATH
+
+      Convert JSON files under PATH into a PFB file.
+
+    Options:
+      -s, --schema FILENAME  The PFB file to load the schema from.  [required]
+      -o, --output FILENAME  The result PFB file.  [required]
+      --program TEXT         Name of the program.  [required]
+      --project TEXT         Name of the project.  [required]
 
 ### Make new blank record
 
-    usage: pypfb make [-h] [-n NODE] input
-    
-    positional arguments:
-      input                 Path to PFB file
-    
-    optional arguments:
-      -h, --help            show this help message and exit
-      -n NODE, --node NODE  Node to create
+    Usage: pfb make [OPTIONS] PFB
+
+      Make blank record from the PFB file.
+
+    Options:
+      -n, --node TEXT  Node to create.  [required]
 
 ### Add new record to PFB
 
-    usage: pypfb add [-h] PFB_file JSON_file
-    
-    Add a record to PFB file from a minified JSON file
-    
-    positional arguments:
-      PFB_file    pfb file to add record to. Default = test.pfb
-      JSON_file   JSON file to add into the pfb file. Default = test.json
-    
-    optional arguments:
-      -h, --help  show this help message and exit
+    Usage: pfb add [OPTIONS] JSON PFB
+
+      Add a record from a minified JSON file to the PFB file.
 
 ### Rename different parts of PFB (schema evolution)
 
-    usage: pypfb rename [-h] {node,type,enum} ...
-    
-    positional arguments:
-      {node,type,enum}
-        node            Rename node
-        type            Rename type (not implemented)
-        enum            Rename enum
-    
-    optional arguments:
-      -h, --help        show this help message and exit
+    Usage: pfb rename [OPTIONS] COMMAND [ARGS]...
+
+      Rename different parts of schema.
+
+    Options:
+      -i, --input FILENAME   Source PFB file.  [required]
+      -o, --output FILENAME  Destination PFB file.  [required]
+
+    Commands:
+      enum  Rename enum.
+      node  Rename node.
+      type  Rename type (not implemented).
 
 ### Rename node
 
-    usage: pypfb rename node [-h] -i INPUT -o OUTPUT --name_from NAME_FROM
-                                   --name_to NAME_TO
-    
-    optional arguments:
-      -h, --help            show this help message and exit
-      -i INPUT, --input INPUT
-      -o OUTPUT, --output OUTPUT
-      --name_from NAME_FROM
-      --name_to NAME_TO
-      
+    Usage: pfb rename [PARENT OPTIONS] node [OPTIONS]
+
+      Rename node.
+
+    Options:
+      --from TEXT  [required]
+      --to TEXT    [required]
+
 ### Rename enum
 
-    usage: pypfb rename enum [-h] -i INPUT -o OUTPUT --field_name FILED_NAME --val_from VALUE_FROM
-                                   --val_to VALUE_TO
-    
-    optional arguments:
-      -h, --help            show this help message and exit
-      -i INPUT, --input INPUT
-      -o OUTPUT, --output OUTPUT
-      --field_name FIELD_NAME
-      --val_from VALUE_FROM
-      --val_to VALUE_TO
-      
+    Usage: pfb rename [PARENT OPTIONS] enum [OPTIONS]
+
+      Rename enum.
+
+    Options:
+      --field TEXT  [required]
+      --from TEXT   [required]
+      --to TEXT     [required]
+
 
 ## Examples
 
-    pfb dict2pfb -d http://s3.amazonaws.com/dictionary-artifacts/kf-dictionary/1.1.0/schema.json -o ./tests/schema/kf.avro
+    pfb from dict http://s3.amazonaws.com/dictionary-artifacts/kf-dictionary/1.1.0/schema.json -o ./tests/schema/kf.avro
     
-    pfb json2pfb ./tests/data -s ./tests/schema/kf.avro -o tests/pfb-data/test.avro --program DEV --project test
+    pfb from json ./tests/data -s ./tests/schema/kf.avro -o tests/pfb-data/test.avro --program DEV --project test
 
-    pfb rename node --name_from slide --name_to slide_test -i tests/pfb-data/test.avro -o tests/pfb-data/rename_test.avro
+    pfb rename -i tests/pfb-data/test.avro -o tests/pfb-data/rename_test.avro node --name_from slide --name_to slide_test
     
-    pfb rename enum --field_name state --val_from validated --val_to validated_test -i tests/pfb-data/test.avro -o tests/pfb-data/rename_test.avro
+    pfb rename -i tests/pfb-data/test.avro -o tests/pfb-data/rename_test.avro enum --field_name state --val_from validated --val_to validated_test
     
     pfb show -s --limit -1 tests/pfb-data/test.avro 
 

--- a/pypfb/__main__.py
+++ b/pypfb/__main__.py
@@ -1,8 +1,9 @@
-import os
-import argparse
 import itertools
+import json
 import logging.config
+import os
 
+import click
 import yaml
 
 from .avro_utils.avro_schema import AvroSchema
@@ -26,141 +27,137 @@ else:
 log = logging.getLogger()
 
 
+@click.group()
 def main():
-    parser = argparse.ArgumentParser(description="PFB tool")
+    """PFB: Portable Format for Biomedical Data."""
 
-    subparsers = parser.add_subparsers(dest="cmd")
 
-    read_cmd = subparsers.add_parser(
-        "show", help="Show schema or records of the PFB file"
-    )
-    read_cmd.add_argument("input", type=str, help="Path to PFB file")
-    read_cmd.add_argument(
-        "-s", "--schema", action="store_true", help="Show PFB file schema"
-    )
-    read_cmd.add_argument(
-        "--limit",
-        type=int,
-        required=False,
-        help='How many entries to show, -1 for all; ignored for "schema"',
-    )
+@main.command()
+@click.argument("input_file", metavar="PFB")
+@click.option("-s", "--schema", is_flag=True, help="Show PFB file schema.")
+@click.option(
+    "--limit",
+    type=int,
+    help='How many entries to show, -1 for all; ignored for "schema".',
+)
+def show(input_file, schema, limit):
+    """Show schema or records of the PFB file."""
+    if schema:
+        print(json.dumps(Gen3PFB(input_file).read_metadata()))
+    else:
+        limit = limit if limit != -1 else None
+        for r in itertools.islice(Gen3PFB(input_file).read_records(), limit):
+            print(json.dumps(r))
 
-    if init_dictionary is not None:
-        dict2pfb_cmd = subparsers.add_parser(
-            "dict2pfb", help="Convert datadictionary into PFB file with schema"
-        )
-        dict2pfb_cmd.add_argument(
-            "-d", "--dictionary", required=True, type=str, help="Link to dictionary URL"
-        )
-        dict2pfb_cmd.add_argument(
-            "-o",
-            "--output",
-            required=True,
-            type=argparse.FileType("wb"),
-            help="Output PFB file",
-        )
 
-    json2pfb_cmd = subparsers.add_parser(
-        "json2pfb", help="Convert JSON files correspond to datadictionary into PFB file"
-    )
-    json2pfb_cmd.add_argument(
-        "dir", type=str, help="Path to directory with input JSON files"
-    )
-    json2pfb_cmd.add_argument(
-        "-s", "--schema", type=str, required=True, help="Filename for schema PFB file"
-    )
-    json2pfb_cmd.add_argument(
-        "-o",
-        "--output",
-        type=str,
-        required=True,
-        help="Filename for resulting PFB file",
-    )
-    json2pfb_cmd.add_argument(
-        "--program", type=str, required=True, help="Name of the program"
-    )
-    json2pfb_cmd.add_argument(
-        "--project", type=str, required=True, help="Name of the project"
-    )
+@main.group("from")
+def from_command():
+    """Generate PFB from other data formats."""
 
-    make_cmd = subparsers.add_parser("make", help="Make blank record")
-    make_cmd.add_argument("input", type=str, help="Path to PFB file")
-    make_cmd.add_argument("-n", "--node", type=str, help="Node to create")
 
-    add_cmd = subparsers.add_parser(
-        "add", description="Add a record to PFB file from a minified JSON file"
+if init_dictionary is not None:
+
+    @from_command.command("dict")
+    @click.argument("url")
+    @click.option(
+        "-o", "--output", required=True, type=click.File("wb"), help="Output PFB file."
     )
-    add_cmd.add_argument(
-        "PFB_file",
-        type=str,
-        default="test.pfb",
-        help="pfb file to add record to. Default = test.pfb",
-    )
-    add_cmd.add_argument(
-        "JSON_file",
-        type=str,
-        default="test.json",
-        help="JSON file to add into the pfb file. Default = test.json",
-    )
-
-    rename = subparsers.add_parser("rename", help="Rename different parts of schema")
-
-    sub_rename = rename.add_subparsers(dest="rename")
-    node_rename = sub_rename.add_parser("node", help="Rename node")
-    node_rename.add_argument("-i", "--input", type=str, required=True, help="")
-    node_rename.add_argument("-o", "--output", type=str, required=True, help="")
-    node_rename.add_argument("--name_from", type=str, required=True, help="")
-    node_rename.add_argument("--name_to", type=str, required=True, help="")
-
-    type_rename = sub_rename.add_parser("type", help="Rename type (not implemented)")
-    type_rename.add_argument("-i", "--input", type=str, required=True, help="")
-    type_rename.add_argument("-o", "--output", type=str, required=True, help="")
-    type_rename.add_argument("--name_from", type=str, required=True, help="")
-    type_rename.add_argument("--name_to", type=str, required=True, help="")
-
-    enum_rename = sub_rename.add_parser("enum", help="Rename enum (not implemented)")
-    enum_rename.add_argument("-i", "--input", type=str, required=True, help="")
-    enum_rename.add_argument("-o", "--output", type=str, required=True, help="")
-    enum_rename.add_argument("--field_name", type=str, required=True, help="")
-    enum_rename.add_argument("--val_from", type=str, required=True, help="")
-    enum_rename.add_argument("--val_to", type=str, required=True, help="")
-
-    args = parser.parse_args()
-
-    if args.cmd == "dict2pfb":
-        dictionary, _ = init_dictionary(args.dictionary)
+    def dict_command(url, output):
+        """Convert Gen3 data dictionary at URL into PFB file."""
+        dictionary, _ = init_dictionary(url)
         schema = dictionary.schema
 
-        log.info("Using dictionary: {}".format(args.dictionary))
+        log.info("Using dictionary: {}".format(url))
 
         avro_schema = AvroSchema.from_dictionary(schema)
-        avro_schema.write(args.output)
+        avro_schema.write(output)
 
-    elif args.cmd == "json2pfb":
-        Gen3PFB.from_json(
-            args.schema, args.dir, args.output, args.program, args.project
-        )
 
-    elif args.cmd == "show":
-        if args.schema:
-            print(Gen3PFB(args.input).read_metadata())
-        else:
-            limit = args.limit if args.limit != -1 else None
-            for r in itertools.islice(Gen3PFB(args.input).read_records(), limit):
-                print(r)
-    elif args.cmd == "make":
-        Gen3PFB(args.input).make_record(args.node)
+@from_command.command("json")
+@click.argument("path")
+@click.option(
+    "-s",
+    "--schema",
+    metavar="FILENAME",
+    required=True,
+    help="The PFB file to load the schema from.",
+)
+@click.option(
+    "-o", "--output", metavar="FILENAME", required=True, help="The result PFB file."
+)
+@click.option("--program", required=True, help="Name of the program.")
+@click.option("--project", required=True, help="Name of the project.")
+def json_command(path, schema, output, program, project):
+    """Convert JSON files under PATH into a PFB file."""
+    Gen3PFB.from_json(schema, path, output, program, project)
 
-    elif args.cmd == "add":
-        Gen3PFB(args.PFB_file).add_record(args.JSON_file)
 
-    elif args.cmd == "rename":
-        if args.rename == "node":
-            Gen3PFB(args.input).rename_node(args.output, args.name_from, args.name_to)
-        elif args.rename == "enum":
-            Gen3PFB(args.input).rename_field_enum(
-                args.output, args.field_name, args.val_from, args.val_to
-            )
+@main.command()
+@click.argument("path", metavar="PFB")
+@click.option("-n", "--node", required=True, help="Node to create.")
+def make(path, node):
+    """Make blank record from the PFB file."""
+    Gen3PFB(path).make_record(node)
+
+
+@main.command()
+@click.argument("json_file", metavar="JSON")
+@click.argument("pfb_file", metavar="PFB")
+def add(json_file, pfb_file):
+    """Add a record from a minified JSON file to the PFB file."""
+    Gen3PFB(pfb_file).add_record(json_file)
+
+
+@main.group()
+@click.option(
+    "-i",
+    "--input",
+    "input_file",
+    metavar="FILENAME",
+    required=True,
+    help="Source PFB file.",
+)
+@click.option(
+    "-o",
+    "--output",
+    "output_file",
+    metavar="FILENAME",
+    required=True,
+    help="Destination PFB file.",
+)
+@click.pass_context
+def rename(ctx, input_file, output_file):
+    """Rename different parts of schema."""
+    ctx.ensure_object(dict)
+    ctx.obj["pfb"] = Gen3PFB(input_file)
+    ctx.obj["output"] = output_file
+
+
+@rename.command("node")
+@click.option("--from", "name_from", required=True, help="")
+@click.option("--to", "name_to", required=True, help="")
+@click.pass_context
+def node_command(ctx, name_from, name_to):
+    """Rename node."""
+    ctx.obj["pfb"].rename_node(ctx.obj["output"], name_from, name_to)
+
+
+@rename.command("type")
+@click.option("--from", "name_from", required=True, help="")
+@click.option("--to", "name_to", required=True, help="")
+@click.pass_context
+def type_command(ctx, name_from, name_to):
+    """Rename type (not implemented)."""
+
+
+@rename.command("enum")
+@click.option("--field", required=True, help="")
+@click.option("--from", "val_from", required=True, help="")
+@click.option("--to", "val_to", required=True, help="")
+@click.pass_context
+def enum_command(ctx, field, val_from, val_to):
+    """Rename enum."""
+    ctx.obj["pfb"].rename_field_enum(ctx.obj["output"], field, val_from, val_to)
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,11 @@ setup(
         "Topic :: Software Development :: Libraries",
         "Topic :: Scientific/Engineering :: Bio-Informatics",
     ],
-    install_requires=["fastavro~=0.21", "python-json-logger~=0.1", "PyYAML~=5.1"],
+    install_requires=[
+        "click~=7.0",
+        "fastavro~=0.21",
+        "python-json-logger~=0.1",
+        "PyYAML~=5.1",
+    ],
     extras_require=dict(gen3=["gen3datamodel~=2.0"]),
 )


### PR DESCRIPTION
This is more like a personal taste thing - I prefer the command definition (options, arguments, etc.) stay close to its implementation.

<!---
Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/)
before asking for review.
--->

- [x] Describe what this pull request does.
- [x] Make sure all tests pass.
- [x] Maintain or increase test coverage.
- [x] Black the code.
- [x] Test manually.
- [x] Remove empty sections below.
- [x] #16 merged

### Breaking Changes
- CLI rearranged: `pfb dict2pfb -d` is now `pfb from dict`, `pfb json2pfb` is now `pfb from json`, `pfb rename` now takes `-i/-o` before subcommand.