### PR TITLE
make sure null is in first position when no default is given

### DIFF
--- a/pfb/importers/gen3dict.py
+++ b/pfb/importers/gen3dict.py
@@ -181,6 +181,10 @@ def _parse_dictionary(d):
                 elif avro_type == "string":
                     t["default"] = ""
                 else:
+                    # if theres no default and null is not the first type then we need to fix order per avro spec
+                    if isinstance(avro_type, list) and avro_type[0] != "null":
+                        avro_type.insert(0, avro_type.pop(avro_type.index("null")))
+                        t["type"] = avro_type
                     t["default"] = None
 
                 types.append(t)


### PR DESCRIPTION
If no default is given we make default = None. As per the avro spec "null" type must be the first type in union if default is null

<!---
Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/)
before asking for review.
--->

- [ ] Describe what this pull request does.
- [ ] Make sure all tests pass.
- [ ] Maintain or increase test coverage.
- [ ] Black the code.
- [ ] Test manually.
- [ ] Remove empty sections below.

### New Features
- Implemented XXX

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

