### PR TITLE
chore(qa): Introduce gen3git release automation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,44 @@
+name: PyPFB release
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  build-and-run:
+    name: Build and Run
+    runs-on: ubuntu-latest
+    if: contains( github.event.pull_request.labels.*.name, 'release')
+    steps:
+      - uses: actions/checkout@v1
+      - name: 'Get Previous tag'
+        id: previoustag
+        uses: "WyriHaximus/github-action-get-previous-tag@master"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GEN3_GITHUB_TOKEN }}"
+      - name: fix remote
+        run: git remote set-url origin https://github.com/uc-cdis/pypfb.git
+      - name: switch to master branch
+        run: git checkout master
+      - name: Bump release version
+        id: bump_version
+        uses: christian-draeger/increment-semantic-version@1.0.0
+        with:
+          current-version: ${{ steps.previoustag.outputs.tag }}
+          version-fragment: 'bug'
+      - name: Install Gen3 release-helper
+        run: |
+          pip install wheel
+          pip install --user --editable git+https://github.com/uc-cdis/release-helper.git@master#egg=gen3git
+          python -m gen3git --github-access-token ${{ secrets.GEN3_GITHUB_TOKEN }} tag ${{ steps.bump_version.outputs.next-version }}
+          python -m gen3git --github-access-token ${{ secrets.GEN3_GITHUB_TOKEN }} --from-tag ${{ steps.previoustag.outputs.tag }} release
+          python -m gen3git --github-access-token ${{ secrets.GEN3_GITHUB_TOKEN }} --from-tag ${{ steps.previoustag.outputs.tag }} gen --markdown
+          cat release_notes.md
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.bump_version.outputs.next-version }}
+          artifacts: "release.tar.gz,foo/*.txt"
+          bodyFile: "release_notes.md"
+          token: ${{ secrets.GEN3_GITHUB_TOKEN }}


### PR DESCRIPTION
Automate gen3git release generation for PRs with the `release` label.

### New Features
- Github action to produce a new release for PRs labeled with `release`.