### PR TITLE
chore(deploy): only deploy to pypi for a single python version to avo…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ deploy:
   skip_cleanup: true
   script: poetry publish -n -vv -r testpypi || true
   on:
+    python: 3.6
     repo: uc-cdis/pypfb
     tags: false
     all_branches: true
@@ -43,6 +44,7 @@ deploy:
   skip_cleanup: true
   script: poetry publish -n -vv
   on:
+    python: 3.6
     repo: uc-cdis/pypfb
     tags: true
 env:

--- a/poetry.lock
+++ b/poetry.lock
@@ -159,8 +159,8 @@ category = "main"
 description = "Fast read/write of AVRO files"
 name = "fastavro"
 optional = false
-python-versions = ">=3.0"
-version = "1.2.0"
+python-versions = ">=3.6"
+version = "1.2.1"
 
 [package.extras]
 codecs = ["python-snappy", "zstandard", "lz4"]
@@ -325,8 +325,8 @@ category = "main"
 description = "multidict implementation"
 name = "multidict"
 optional = false
-python-versions = ">=3.5"
-version = "5.0.2"
+python-versions = ">=3.6"
+version = "5.1.0"
 
 [[package]]
 category = "main"
@@ -594,7 +594,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-content-hash = "b5dc27b0c4d598967e35b0f98a5c3e28fb48dd69975a31d652b903528c6beaee"
+content-hash = "5ab874d4dfc7a26c1a1615baf546112a81ca049eae0908016a0f94f4bb31b381"
 python-versions = ">=3.6.1,<3.8"
 
 [metadata.files]
@@ -721,22 +721,22 @@ dictionaryutils = [
     {file = "dictionaryutils-3.2.0.tar.gz", hash = "sha256:e1949e5ec6183f94c4841c296c91c8cf86139504625d849d089e2f49b726734b"},
 ]
 fastavro = [
-    {file = "fastavro-1.2.0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:fac9ecf8babd90f9d1da080180fdde6b4c1f1c63ed03adb17aa1b0caa09c2bdc"},
-    {file = "fastavro-1.2.0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:7b7e9872e8ff37d9ee274ba3a3bfc672fcbfa65f231071a7d53df6fe42a72f69"},
-    {file = "fastavro-1.2.0-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:5f5b13e9eb0ba6a1351e3d218763c2514e53a95135eb20e3e1d8eb4e6160a5a1"},
-    {file = "fastavro-1.2.0-cp36-cp36m-win_amd64.whl", hash = "sha256:213038249aa6ee83a2ae6da22a55008cc08bf15f8089f86da38d375a4092bec0"},
-    {file = "fastavro-1.2.0-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:315e1d6da9be7512246977d1e89b77dedd72ab914c6f4f6af5409d24a16eae51"},
-    {file = "fastavro-1.2.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:2a4073fc831fbe0ea8ecb6c5d12cd5c7c947aff609c35a3020f99204cfed10d4"},
-    {file = "fastavro-1.2.0-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:4b207b11cee694f30875eb9bc05271ef165e2a4a509b1f116b3b10dcbef1de6b"},
-    {file = "fastavro-1.2.0-cp37-cp37m-win_amd64.whl", hash = "sha256:1ff45a051798feee8fd521e700eb6315afe741b7014644bb50454e32a35819a9"},
-    {file = "fastavro-1.2.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:5a5dd6defe7b4e9e07fce85a863414e1b898257a889de0bb3240f9c91ab25695"},
-    {file = "fastavro-1.2.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:9964eb776d705dee923c55a488d118995637b0e3535f94e84d04285ba5a27d36"},
-    {file = "fastavro-1.2.0-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:a8abe3347b322925da8b5a97961ed87111db97e18e03195a6aedad8709a47136"},
-    {file = "fastavro-1.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:9223f4af6e14d985c59fb2e85788927725a6e2b37530ae65f4cce33f9af2b113"},
-    {file = "fastavro-1.2.0-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:a0fc504908da59bd3610d0d544bb8845746f82aa169c4c1fb1547e31bc783c51"},
-    {file = "fastavro-1.2.0-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:c787d793e9b2e4e12d03ae2b0abb52625717d3f4d3161c841bd09dc2520b67a1"},
-    {file = "fastavro-1.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:bc65d74c35d2ae53af0647e9ffa008c6fdb41e0a9c37e34c5681d915437db8ee"},
-    {file = "fastavro-1.2.0.tar.gz", hash = "sha256:9f80c8d87b6d5ec4294caaa15ea8381724e71638c5bdf33af9a0b4d739e8860f"},
+    {file = "fastavro-1.2.1-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:e1604e682a5ba676ffb9b10e6a798c01c3cd7cdfa4dde863f7b95eff25eab7b7"},
+    {file = "fastavro-1.2.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:54966b195fffd7131104028b7bc82f3825515e5d60da5d123e483ca558ecae7d"},
+    {file = "fastavro-1.2.1-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:9309c83289288816c5b6675220fed1420e75bb64f44ac8ed41e4ac747227ed61"},
+    {file = "fastavro-1.2.1-cp36-cp36m-win_amd64.whl", hash = "sha256:eb7daf7d1cd61358a17076b2b69f4af0fed9212d61dac10b83e4747e88e8d0fc"},
+    {file = "fastavro-1.2.1-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:2198503c8a93328e7d23a919d4bb71dec8397a0988f757e606949535f9a1935c"},
+    {file = "fastavro-1.2.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:8be29b2e32f60f2083403d68c6ec60b441f1f048592434e3fe297a3e26afb2c7"},
+    {file = "fastavro-1.2.1-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:210f2212beee2ce0b1deb24e9d6eccac3b82132bd47418d65f9e72ffbbec3cba"},
+    {file = "fastavro-1.2.1-cp37-cp37m-win_amd64.whl", hash = "sha256:db150a7c86a06c8fd822d47497c20228435f30dbc8e9101a748772df69c3c3dd"},
+    {file = "fastavro-1.2.1-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:745feb862db81ed6998389709b6561bf95f4f99170ef2e6a8de06fa4c4de030a"},
+    {file = "fastavro-1.2.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:c4fc6ccf4c9af37c43d8d166fd3726ad85375e7e0362581ccbf87d7b193dc3b6"},
+    {file = "fastavro-1.2.1-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:143e0f85872d82ee1195d7b7a69c0ca9bb9eebf8e0b31440b831b7003b3ae5d0"},
+    {file = "fastavro-1.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:0a95bdf62b274417dfd1ed072e31059b598407b9401e56d70bca02c25724364e"},
+    {file = "fastavro-1.2.1-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:86d69475e8980e4837f9a8f1970d1c8988b01d801757c8a2eb7490be34e9b6e1"},
+    {file = "fastavro-1.2.1-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:af04098dadc28d370732d7909a60aeaf15fd4aebbbcdaf68fff288dafcd3b7b5"},
+    {file = "fastavro-1.2.1-cp39-cp39-win_amd64.whl", hash = "sha256:c67606b25820dc4616b51948d34d54d75c2c1a8ac61fd1b881591599db7a9127"},
+    {file = "fastavro-1.2.1.tar.gz", hash = "sha256:49a88f1007617eecec8d9d00584de9c17e3eb806b5ecce779c8e882832bf786f"},
 ]
 gdcdictionary = [
     {file = "gdcdictionary-1.2.0-py2.7.egg", hash = "sha256:596e82fead5653beb8296ca505fb9f6e3d51c631e6605312406b4118fc7c42ae"},
@@ -783,43 +783,43 @@ more-itertools = [
     {file = "more_itertools-8.6.0-py3-none-any.whl", hash = "sha256:8e1a2a43b2f2727425f2b5839587ae37093f19153dc26c0927d1048ff6557330"},
 ]
 multidict = [
-    {file = "multidict-5.0.2-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:b82400ef848bbac6b9035a105ac6acaa1fb3eea0d164e35bbb21619b88e49fed"},
-    {file = "multidict-5.0.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:b98af08d7bb37d3456a22f689819ea793e8d6961b9629322d7728c4039071641"},
-    {file = "multidict-5.0.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:d4a6fb98e9e9be3f7d70fd3e852369c00a027bd5ed0f3e8ade3821bcad257408"},
-    {file = "multidict-5.0.2-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:2ab9cad4c5ef5c41e1123ed1f89f555aabefb9391d4e01fd6182de970b7267ed"},
-    {file = "multidict-5.0.2-cp36-cp36m-manylinux2014_ppc64le.whl", hash = "sha256:62abab8088704121297d39c8f47156cb8fab1da731f513e59ba73946b22cf3d0"},
-    {file = "multidict-5.0.2-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:59182e975b8c197d0146a003d0f0d5dc5487ce4899502061d8df585b0f51fba2"},
-    {file = "multidict-5.0.2-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:76cbdb22f48de64811f9ce1dd4dee09665f84f32d6a26de249a50c1e90e244e0"},
-    {file = "multidict-5.0.2-cp36-cp36m-win32.whl", hash = "sha256:653b2bbb0bbf282c37279dd04f429947ac92713049e1efc615f68d4e64b1dbc2"},
-    {file = "multidict-5.0.2-cp36-cp36m-win_amd64.whl", hash = "sha256:c58e53e1c73109fdf4b759db9f2939325f510a8a5215135330fe6755921e4886"},
-    {file = "multidict-5.0.2-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:359ea00e1b53ceef282232308da9d9a3f60d645868a97f64df19485c7f9ef628"},
-    {file = "multidict-5.0.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:b561e76c9e21402d9a446cdae13398f9942388b9bff529f32dfa46220af54d00"},
-    {file = "multidict-5.0.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:9380b3f2b00b23a4106ba9dd022df3e6e2e84e1788acdbdd27603b621b3288df"},
-    {file = "multidict-5.0.2-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:1cd102057b09223b919f9447c669cf2efabeefb42a42ae6233f25ffd7ee31a79"},
-    {file = "multidict-5.0.2-cp37-cp37m-manylinux2014_ppc64le.whl", hash = "sha256:d99da85d6890267292065e654a329e1d2f483a5d2485e347383800e616a8c0b1"},
-    {file = "multidict-5.0.2-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:f612e8ef8408391a4a3366e3508bab8ef97b063b4918a317cb6e6de4415f01af"},
-    {file = "multidict-5.0.2-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:6128d2c0956fd60e39ec7d1c8f79426f0c915d36458df59ddd1f0cff0340305f"},
-    {file = "multidict-5.0.2-cp37-cp37m-win32.whl", hash = "sha256:9ed9b280f7778ad6f71826b38a73c2fdca4077817c64bc1102fdada58e75c03c"},
-    {file = "multidict-5.0.2-cp37-cp37m-win_amd64.whl", hash = "sha256:f65a2442c113afde52fb09f9a6276bbc31da71add99dc76c3adf6083234e07c6"},
-    {file = "multidict-5.0.2-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:2576e30bbec004e863d87216bc34abe24962cc2e964613241a1c01c7681092ab"},
-    {file = "multidict-5.0.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:20cc9b2dd31761990abff7d0e63cd14dbfca4ebb52a77afc917b603473951a38"},
-    {file = "multidict-5.0.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:6566749cd78cb37cbf8e8171b5cd2cbfc03c99f0891de12255cf17a11c07b1a3"},
-    {file = "multidict-5.0.2-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:6168839491a533fa75f3f5d48acbb829475e6c7d9fa5c6e245153b5f79b986a3"},
-    {file = "multidict-5.0.2-cp38-cp38-manylinux2014_ppc64le.whl", hash = "sha256:e58db0e0d60029915f7fc95a8683fa815e204f2e1990f1fb46a7778d57ca8c35"},
-    {file = "multidict-5.0.2-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:8fa4549f341a057feec4c3139056ba73e17ed03a506469f447797a51f85081b5"},
-    {file = "multidict-5.0.2-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:06f39f0ddc308dab4e5fa282d145f90cd38d7ed75390fc83335636909a9ec191"},
-    {file = "multidict-5.0.2-cp38-cp38-win32.whl", hash = "sha256:8efcf070d60fd497db771429b1c769a3783e3a0dd96c78c027e676990176adc5"},
-    {file = "multidict-5.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:060d68ae3e674c913ec41a464916f12c4d7ff17a3a9ebbf37ba7f2c681c2b33e"},
-    {file = "multidict-5.0.2-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:4a3f19da871befa53b48dd81ee48542f519beffa13090dc135fffc18d8fe36db"},
-    {file = "multidict-5.0.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:af271c2540d1cd2a137bef8d95a8052230aa1cda26dd3b2c73d858d89993d518"},
-    {file = "multidict-5.0.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:3e61cc244fd30bd9fdfae13bdd0c5ec65da51a86575ff1191255cae677045ffe"},
-    {file = "multidict-5.0.2-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:4df708ef412fd9b59b7e6c77857e64c1f6b4c0116b751cb399384ec9a28baa66"},
-    {file = "multidict-5.0.2-cp39-cp39-manylinux2014_ppc64le.whl", hash = "sha256:cbabfc12b401d074298bfda099c58dfa5348415ae2e4ec841290627cb7cb6b2e"},
-    {file = "multidict-5.0.2-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:43c7a87d8c31913311a1ab24b138254a0ee89142983b327a2c2eab7a7d10fea9"},
-    {file = "multidict-5.0.2-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:fa0503947a99a1be94f799fac89d67a5e20c333e78ddae16e8534b151cdc588a"},
-    {file = "multidict-5.0.2-cp39-cp39-win32.whl", hash = "sha256:17847fede1aafdb7e74e01bb34ab47a1a1ea726e8184c623c45d7e428d2d5d34"},
-    {file = "multidict-5.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:a7b8b5bd16376c8ac2977748bd978a200326af5145d8d0e7f799e2b355d425b6"},
-    {file = "multidict-5.0.2.tar.gz", hash = "sha256:e5bf89fe57f702a046c7ec718fe330ed50efd4bcf74722940db2eb0919cddb1c"},
+    {file = "multidict-5.1.0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:b7993704f1a4b204e71debe6095150d43b2ee6150fa4f44d6d966ec356a8d61f"},
+    {file = "multidict-5.1.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:9dd6e9b1a913d096ac95d0399bd737e00f2af1e1594a787e00f7975778c8b2bf"},
+    {file = "multidict-5.1.0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:f21756997ad8ef815d8ef3d34edd98804ab5ea337feedcd62fb52d22bf531281"},
+    {file = "multidict-5.1.0-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:1ab820665e67373de5802acae069a6a05567ae234ddb129f31d290fc3d1aa56d"},
+    {file = "multidict-5.1.0-cp36-cp36m-manylinux2014_ppc64le.whl", hash = "sha256:9436dc58c123f07b230383083855593550c4d301d2532045a17ccf6eca505f6d"},
+    {file = "multidict-5.1.0-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:830f57206cc96ed0ccf68304141fec9481a096c4d2e2831f311bde1c404401da"},
+    {file = "multidict-5.1.0-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:2e68965192c4ea61fff1b81c14ff712fc7dc15d2bd120602e4a3494ea6584224"},
+    {file = "multidict-5.1.0-cp36-cp36m-win32.whl", hash = "sha256:2f1a132f1c88724674271d636e6b7351477c27722f2ed789f719f9e3545a3d26"},
+    {file = "multidict-5.1.0-cp36-cp36m-win_amd64.whl", hash = "sha256:3a4f32116f8f72ecf2a29dabfb27b23ab7cdc0ba807e8459e59a93a9be9506f6"},
+    {file = "multidict-5.1.0-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:46c73e09ad374a6d876c599f2328161bcd95e280f84d2060cf57991dec5cfe76"},
+    {file = "multidict-5.1.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:018132dbd8688c7a69ad89c4a3f39ea2f9f33302ebe567a879da8f4ca73f0d0a"},
+    {file = "multidict-5.1.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:4b186eb7d6ae7c06eb4392411189469e6a820da81447f46c0072a41c748ab73f"},
+    {file = "multidict-5.1.0-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:3a041b76d13706b7fff23b9fc83117c7b8fe8d5fe9e6be45eee72b9baa75f348"},
+    {file = "multidict-5.1.0-cp37-cp37m-manylinux2014_ppc64le.whl", hash = "sha256:051012ccee979b2b06be928a6150d237aec75dd6bf2d1eeeb190baf2b05abc93"},
+    {file = "multidict-5.1.0-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:6a4d5ce640e37b0efcc8441caeea8f43a06addace2335bd11151bc02d2ee31f9"},
+    {file = "multidict-5.1.0-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:5cf3443199b83ed9e955f511b5b241fd3ae004e3cb81c58ec10f4fe47c7dce37"},
+    {file = "multidict-5.1.0-cp37-cp37m-win32.whl", hash = "sha256:f200755768dc19c6f4e2b672421e0ebb3dd54c38d5a4f262b872d8cfcc9e93b5"},
+    {file = "multidict-5.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:05c20b68e512166fddba59a918773ba002fdd77800cad9f55b59790030bab632"},
+    {file = "multidict-5.1.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:54fd1e83a184e19c598d5e70ba508196fd0bbdd676ce159feb412a4a6664f952"},
+    {file = "multidict-5.1.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:0e3c84e6c67eba89c2dbcee08504ba8644ab4284863452450520dad8f1e89b79"},
+    {file = "multidict-5.1.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:dc862056f76443a0db4509116c5cd480fe1b6a2d45512a653f9a855cc0517456"},
+    {file = "multidict-5.1.0-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:0e929169f9c090dae0646a011c8b058e5e5fb391466016b39d21745b48817fd7"},
+    {file = "multidict-5.1.0-cp38-cp38-manylinux2014_ppc64le.whl", hash = "sha256:d81eddcb12d608cc08081fa88d046c78afb1bf8107e6feab5d43503fea74a635"},
+    {file = "multidict-5.1.0-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:585fd452dd7782130d112f7ddf3473ffdd521414674c33876187e101b588738a"},
+    {file = "multidict-5.1.0-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:37e5438e1c78931df5d3c0c78ae049092877e5e9c02dd1ff5abb9cf27a5914ea"},
+    {file = "multidict-5.1.0-cp38-cp38-win32.whl", hash = "sha256:07b42215124aedecc6083f1ce6b7e5ec5b50047afa701f3442054373a6deb656"},
+    {file = "multidict-5.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:929006d3c2d923788ba153ad0de8ed2e5ed39fdbe8e7be21e2f22ed06c6783d3"},
+    {file = "multidict-5.1.0-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:b797515be8743b771aa868f83563f789bbd4b236659ba52243b735d80b29ed93"},
+    {file = "multidict-5.1.0-cp39-cp39-manylinux1_i686.whl", hash = "sha256:d5c65bdf4484872c4af3150aeebe101ba560dcfb34488d9a8ff8dbcd21079647"},
+    {file = "multidict-5.1.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:b47a43177a5e65b771b80db71e7be76c0ba23cc8aa73eeeb089ed5219cdbe27d"},
+    {file = "multidict-5.1.0-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:806068d4f86cb06af37cd65821554f98240a19ce646d3cd24e1c33587f313eb8"},
+    {file = "multidict-5.1.0-cp39-cp39-manylinux2014_ppc64le.whl", hash = "sha256:46dd362c2f045095c920162e9307de5ffd0a1bfbba0a6e990b344366f55a30c1"},
+    {file = "multidict-5.1.0-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:ace010325c787c378afd7f7c1ac66b26313b3344628652eacd149bdd23c68841"},
+    {file = "multidict-5.1.0-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:ecc771ab628ea281517e24fd2c52e8f31c41e66652d07599ad8818abaad38cda"},
+    {file = "multidict-5.1.0-cp39-cp39-win32.whl", hash = "sha256:fc13a9524bc18b6fb6e0dbec3533ba0496bbed167c56d0aabefd965584557d80"},
+    {file = "multidict-5.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:7df80d07818b385f3129180369079bd6934cf70469f99daaebfac89dca288359"},
+    {file = "multidict-5.1.0.tar.gz", hash = "sha256:25b4e5f22d3a37ddf3effc0710ba692cfc792c2b9edfb9c05aefe823256e84d5"},
 ]
 numpy = [
     {file = "numpy-1.19.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e9b30d4bd69498fc0c3fe9db5f62fffbb06b8eb9321f92cc970f2969be5e3949"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pypfb"
-version = "0.5.3"
+version = "0.5.5"
 description = "Python SDK for PFB format"
 authors = ["CTDS UChicago <cdis@uchicago.edu>"]
 license = "Apache-2.0"


### PR DESCRIPTION
…id conflicts, update lock file


### New Features


### Breaking Changes


### Bug Fixes


### Improvements
- only deploy to pypi for a single python version to avoid conflicts, update lock file

### Dependency updates


### Deployment changes
