### PR TITLE
use py3 in our release github action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: PyPFB release
 on:
   pull_request:
     types:
-      - labeled
+      - closed
 
 jobs:
   build-and-run:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: PyPFB release
 on:
   pull_request:
     types:
-      - closed
+      - labeled
 
 jobs:
   build-and-run:
@@ -27,10 +27,10 @@ jobs:
         with:
           current-version: ${{ steps.previoustag.outputs.tag }}
           version-fragment: 'bug'
-      - name: "Upgrade to Python3"
-        uses: cclauss/Upgrade-to-Python3@master
       - name: Install Gen3 release-helper
-        uses: frolvlad/alpine-python3@latest
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
         run: |
           pip install wheel
           python --version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pypfb"
-version = "0.6.1"
+version = "0.5.6"
 description = "Python SDK for PFB format"
 authors = ["CTDS UChicago <cdis@uchicago.edu>"]
 license = "Apache-2.0"


### PR DESCRIPTION
The name of this branch is misleading, the version-bump should consider the latest semver which is `0.5.5`.

Turns out the current github actions container that runs the step to install our `release-helper` is currently running a jurassic version of Python that doesn't like the f-string interpolation from:
https://github.com/uc-cdis/release-helper/blob/master/gen3git.py#L258