### PR TITLE
chore(release): Utilize implicitly-set GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
         id: previoustag
         uses: "WyriHaximus/github-action-get-previous-tag@master"
         env:
-          GITHUB_TOKEN: "${{ secrets.GEN3_GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: fix remote
         run: git remote set-url origin https://github.com/uc-cdis/pypfb.git
       - name: switch to master branch
@@ -36,9 +36,9 @@ jobs:
           pip install wheel
           python --version
           pip install --user --editable git+https://github.com/uc-cdis/release-helper.git@master#egg=gen3git
-          python -m gen3git --github-access-token ${{ secrets.GEN3_GITHUB_TOKEN }} tag ${{ steps.bump_version.outputs.next-version }}
-          python -m gen3git --github-access-token ${{ secrets.GEN3_GITHUB_TOKEN }} --from-tag ${{ steps.previoustag.outputs.tag }} release
-          python -m gen3git --github-access-token ${{ secrets.GEN3_GITHUB_TOKEN }} --from-tag ${{ steps.previoustag.outputs.tag }} gen --markdown
+          python -m gen3git --github-access-token ${{ secrets.GITHUB_TOKEN }} tag ${{ steps.bump_version.outputs.next-version }}
+          python -m gen3git --github-access-token ${{ secrets.GITHUB_TOKEN }} --from-tag ${{ steps.previoustag.outputs.tag }} release
+          python -m gen3git --github-access-token ${{ secrets.GITHUB_TOKEN }} --from-tag ${{ steps.previoustag.outputs.tag }} gen --markdown
           cat release_notes.md
       - name: Create release
         uses: ncipollo/release-action@v1
@@ -46,4 +46,4 @@ jobs:
           tag: ${{ steps.bump_version.outputs.next-version }}
           artifacts: "release.tar.gz,foo/*.txt"
           bodyFile: "release_notes.md"
-          token: ${{ secrets.GEN3_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Let us avoid prefixed GITHUB_TOKEN reference as they require a manual secret entry in the repo's settings.

### Improvements
- Just use `secrets.GITHUB_TOKEN` as it is seamlessly set by the Github Actions system.