### PR TITLE
fix(release-workflow): bump increment-semantic-version action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
         run: git checkout master
       - name: Bump release version
         id: bump_version
-        uses: christian-draeger/increment-semantic-version@1.0.0
+        uses: christian-draeger/increment-semantic-version@1.0.2
         with:
           current-version: ${{ steps.previoustag.outputs.tag }}
           version-fragment: 'bug'


### PR DESCRIPTION
(Nothing is broken at the moment but things may break when incrementing a version with a 0 using the release workflow. Bumping the action version to prevent this.)

### Bug Fixes
- fix release workflow: fix broken increment-semantic-version workflow action by bumping the version
