### PR TITLE
Add links to places where we can report issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,3 +267,7 @@ poetry install
 
 
   [1]: ./doc/schema.svg
+
+## Reporting issues
+
+Issues relating to the PFB format should be reported to [url]. Issues relating to this Python library should be reported to [url].


### PR DESCRIPTION
This PR adds an **incomplete** section to the README file with links to an issue repository where issues with PFB and pypfb can be reported. I would have reported this as a GitHub issue, but your GitHub issues are not accessible to non-project users, so hopefully someone can fill in the correct URLs to use in the README so that we'll know where to report issues in the future :).

**Please do not merge this until a project member has entered the correct URLS!**

### Improvements
- Added a section to the README file that describes how to report issues with PFB and pypfb.