### PR TITLE
chore(py3.8): Tweak python version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pypfb"
-version = "0.5.14"
+version = "0.5.15"
 description = "Python SDK for PFB format"
 authors = ["CTDS UChicago <cdis@uchicago.edu>"]
 license = "Apache-2.0"
@@ -9,12 +9,12 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.6,<3.8"
+python = ">=3.6,<=3.8"
 click = "^7.1.2"
 fastavro = "^1.0.0"
 python-json-logger = "^0.1.11"
 PyYAML = "^5.3.1"
-importlib_metadata = { version = "^1.3.0", python = "<3.8" }
+importlib_metadata = { version = "^1.3.0", python = "<=3.8" }
 gdcdictionary = "^1.2.0"
 aiohttp = "^3.6.3"
 dictionaryutils = "^3.2.0"


### PR DESCRIPTION
Making sure the latest versions of the lib are easily installed with python3.8.

### Improvements
- Allow easy installation of lib while running Python 3.8.0
