### PR TITLE
adding fix for 'show' on array of enums type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pypfb"
-version = "0.5.16"
+version = "0.5.17"
 description = "Python SDK for PFB format"
 authors = ["CTDS UChicago <cdis@uchicago.edu>"]
 license = "Apache-2.0"

--- a/src/pfb/reader.py
+++ b/src/pfb/reader.py
@@ -37,7 +37,13 @@ class PFBReader(PFBBase):
         to_update = {}
         for name, value in list(obj.items()):
             if value and self.is_encode(rv["name"], name):
-                to_update[name] = decode_enum(value)
+                if isinstance(value,list):
+                    thing = []
+                    for val in value:
+                        thing.append(decode_enum(val))
+                    to_update[name] = thing
+                else:
+                    to_update[name] = decode_enum(value)
         obj.update(to_update)
         return rv
 


### PR DESCRIPTION
### Bug Fixes
This is a fix for doing a show on an array of enums. The array was not being flattened before being decoded and was causing an error with `re`
