### PR TITLE
Fix PFB export to TSV in generation of the non required relations column

### DIFF
--- a/src/pfb/exporters/tsv.py
+++ b/src/pfb/exporters/tsv.py
@@ -143,7 +143,7 @@ def _to_tsv(reader, dir_path, handlers_by_name):
                 ):
                     if field["name"] not in obj:
                         continue
-                value = obj[field["name"]]
+                value = obj[field["name"]] if field["name"] in obj else None 
                 data_row.append(value)
 
         w.writerow(data_row)


### PR DESCRIPTION
This PR aim to fix the scenario where an optional relationship is missing, so the column value is not generated by the PFB export to TSV code and the command fails with KeyError.

[row["relations"]](https://github.com/uc-cdis/pypfb/blob/ea54a13a833a27173f376574b5f3aef02d89b41d/src/pfb/exporters/tsv.py#L74) contains a list of the linked entities that have been submitted, but for a non required link the property may be missing. 
Here is an example of two entities:

`[{'dst_id': '06462dd0-1d66-44a9-8191-0dc9774755f0', 'dst_name': 'subject'}, {'dst_id': '56c615bb-ffac-45a7-8d5b-3f4d680e0c74', 'dst_name': 'timing'}]
[{'dst_id': '57cac608-f28d-4bca-9034-0b9feb753e0d', 'dst_name': 'subject'}]`

And the [line](https://github.com/uc-cdis/pypfb/blob/ea54a13a833a27173f376574b5f3aef02d89b41d/src/pfb/exporters/tsv.py#L94) populating the variable expected at the end is not  executed generating the [KeyError](https://github.com/uc-cdis/pypfb/blob/ea54a13a833a27173f376574b5f3aef02d89b41d/src/pfb/exporters/tsv.py#L146).
 
Error log for reference:
`Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/lgraglia/Library/Caches/pypoetry/virtualenvs/pypfb-qxKJGO9L-py3.9/lib/python3.9/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/lgraglia/Library/Caches/pypoetry/virtualenvs/pypfb-qxKJGO9L-py3.9/lib/python3.9/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/lgraglia/Library/Caches/pypoetry/virtualenvs/pypfb-qxKJGO9L-py3.9/lib/python3.9/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/lgraglia/Library/Caches/pypoetry/virtualenvs/pypfb-qxKJGO9L-py3.9/lib/python3.9/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/lgraglia/Library/Caches/pypoetry/virtualenvs/pypfb-qxKJGO9L-py3.9/lib/python3.9/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/lgraglia/Library/Caches/pypoetry/virtualenvs/pypfb-qxKJGO9L-py3.9/lib/python3.9/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/lgraglia/Library/Caches/pypoetry/virtualenvs/pypfb-qxKJGO9L-py3.9/lib/python3.9/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/lgraglia/Projects/GEN3_dev/dev_tools/pypfb/src/pfb/exporters/tsv.py", line 21, in tsv
    num_files = _to_tsv(reader, output, handlers_by_name)
  File "/Users/lgraglia/Projects/GEN3_dev/dev_tools/pypfb/src/pfb/exporters/tsv.py", line 147, in _to_tsv
    value = obj[field["name"]]
KeyError: 'timings.id'`