### PR TITLE
fixing jekyll config for css

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -17,8 +17,6 @@ title: PFB
 email: mlukowski@uchicago.edu
 description: >- # this means to ignore newlines until "baseurl:"
         PFB is developed by the Center for Translational Data Science at the University of Chicago
-baseurl: "" # the subpath of your site, e.g. /blog
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
 
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
### Bug Fixes
when you aren't using a custom url _config.yml can sometimes mess up where the css stylesheet is rendering.