### PR TITLE
Name anonymous inner enums after object/parameter instead of description.

### DIFF
--- a/src/pfb/importers/gen3dict.py
+++ b/src/pfb/importers/gen3dict.py
@@ -239,7 +239,7 @@ def _get_avro_type(property_name, property_type, name):
             # this is for when a type is required in a dictionary and is an array type
             return _required_array_type(property_type)
         if property_type["type"] == ["array", "null"]:
-            return _array_type(property_type)
+            return _array_type(property_name,property_type, name)
         if "number" in property_type["type"]:
             return ["null", "float"]
         if "int" in property_type["type"]:
@@ -267,18 +267,12 @@ def _required_array_type(property_type):
     return end_array_type
 
 
-def _array_type(property_type):
+def _array_type(property_name ,property_type, object_name):
     if "enum" in property_type["items"]:
         enum = {}
         enum["type"] = "enum"
         enum["symbols"] = property_type["items"]["enum"]
-        if "description" in property_type:
-            enum["name"] = property_type["description"]
-        else:
-            enum["name"] = property_type.get("term", {}).get("termDef", {}).get("term")
-            if enum["name"] is None:
-                # This final fallback is to a value that was being used before
-                enum["name"] = property_type["termDef"][0]["term"]
+        enum["name"] = f"{object_name}_{property_name}_anon_enum"
 
         array_type = {}
         array_type["type"] = "array"


### PR DESCRIPTION
### New Features

### Breaking Changes

### Bug Fixes
This change seeks to change the name of an anonymous inner enum inside an array within the ARVO export. Before this change the Description would be used as the name. In our case we had a property defined on two objects inside the schema, which had the same description, namely:

> consent_codes:
>   description: "Data Use Restrictions that are used to indicate  permissions/restrictions\
>     \ for datasets and/or materials, and relates to the purposes for which datasets\
>     \ and/or material might be removed, stored or used. \\n\n        Based on the\
>     \ Data Use Ontology : see http://www.obofoundry.org/ontology/duo.html"
>   type: array
>   items:
>     enum:
>     - General Research Use
>     - Health or Biomedical Research
>     - Disease Specific Research
>     - not for profit, non commercial user only
>     - ethics approval required
>     - user specific restriction
>     enumDef:
>     - enumeration: General Research Use
>       source: duo
>       term_id: DUO:0000042
>     - enumeration: Health or Biomedical Research
>       source: duo
>       term_id: DUO:0000006
>     - enumeration: Disease Specific Research
>       source: duo
>       term_id: DUO:0000007
>     - enumeration: not for profit, non commercial user only
>       source: duo
>       term_id: DUO:0000018
>     - enumeration: ethics approval required
>       source: duo
>       term_id: DUO:0000021
>     - enumeration: user specific restriction
>       source: duo
>       term_id: DUO:0000026

Trying to compile a PFB from that schema using 

> pfb from -o out.arvo dict PATH_TO_DICT 
lead to this exception: 

> Loading dictionary: /Users/uwewinter/Documents/Biocommons/Gen3/src/ACDCSchemaDev/output/schema/yaml
> Parsing dictionary...
> Writing PFB...
> Failed!
> Traceback (most recent call last):
>   File "/Users/uwewinter/miniforge3/lib/python3.10/runpy.py", line 196, in _run_module_as_main
>     return _run_code(code, main_globals, None,
>   File "/Users/uwewinter/miniforge3/lib/python3.10/runpy.py", line 86, in _run_code
>     exec(code, run_globals)
>   File "/Users/uwewinter/Documents/Biocommons/Gen3/src/pypfb/src/pfb/cli.py", line 93, in <module>
>     main()
>   File "/Users/uwewinter/Library/Caches/pypoetry/virtualenvs/pypfb-Mb0bojc6-py3.10/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
>     return self.main(*args, **kwargs)
>   File "/Users/uwewinter/Library/Caches/pypoetry/virtualenvs/pypfb-Mb0bojc6-py3.10/lib/python3.10/site-packages/click/core.py", line 1078, in main
>     rv = self.invoke(ctx)
>   File "/Users/uwewinter/Library/Caches/pypoetry/virtualenvs/pypfb-Mb0bojc6-py3.10/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
>     return _process_result(sub_ctx.command.invoke(sub_ctx))
>   File "/Users/uwewinter/Library/Caches/pypoetry/virtualenvs/pypfb-Mb0bojc6-py3.10/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
>     return _process_result(sub_ctx.command.invoke(sub_ctx))
>   File "/Users/uwewinter/Library/Caches/pypoetry/virtualenvs/pypfb-Mb0bojc6-py3.10/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
>     return ctx.invoke(self.callback, **ctx.params)
>   File "/Users/uwewinter/Library/Caches/pypoetry/virtualenvs/pypfb-Mb0bojc6-py3.10/lib/python3.10/site-packages/click/core.py", line 783, in invoke
>     return __callback(*args, **kwargs)
>   File "/Users/uwewinter/Library/Caches/pypoetry/virtualenvs/pypfb-Mb0bojc6-py3.10/lib/python3.10/site-packages/click/decorators.py", line 33, in new_func
>     return f(get_current_context(), *args, **kwargs)
>   File "/Users/uwewinter/Documents/Biocommons/Gen3/src/pypfb/src/pfb/importers/gen3dict.py", line 21, in from_dict
>     write_from_dict(writer, url_or_path)
>   File "/Users/uwewinter/Documents/Biocommons/Gen3/src/pypfb/src/pfb/importers/gen3dict.py", line 48, in write_from_dict
>     writer.write()
>   File "/Users/uwewinter/Documents/Biocommons/Gen3/src/pypfb/src/pfb/writer.py", line 246, in write
>     writer(self._file_obj, make_avro_schema(self.schema), _iter())
>   File "fastavro/_write.pyx", line 762, in fastavro._write.writer
>   File "fastavro/_write.pyx", line 670, in fastavro._write.Writer.__init__
>   File "fastavro/_schema.pyx", line 173, in fastavro._schema.parse_schema
>   File "fastavro/_schema.pyx", line 408, in fastavro._schema._parse_schema
>   File "fastavro/_schema.pyx", line 476, in fastavro._schema.parse_field
>   File "fastavro/_schema.pyx", line 229, in fastavro._schema._parse_schema
>   File "fastavro/_schema.pyx", line 408, in fastavro._schema._parse_schema
>   File "fastavro/_schema.pyx", line 476, in fastavro._schema.parse_field
>   File "fastavro/_schema.pyx", line 229, in fastavro._schema._parse_schema
>   File "fastavro/_schema.pyx", line 326, in fastavro._schema._parse_schema
>   File "fastavro/_schema.pyx", line 360, in fastavro._schema._parse_schema
> fastavro._schema_common.SchemaParseException: redefined named type: Data_20_Use_20_Restrictions_20_that_20_are_20_used_20_to_20_indicate_20__20_permissions_2f_restrictions_20_for_20_datasets_20_and_2f_or_20_materials_2c__20_and_20_relates_20_to_20_the_20_purposes_20_for_20_which_20_datasets_20_and_2f_or_20_material_20_might_20_be_20_removed_2c__20_stored_20_or_20_used_2e__20__5c_n_a__20__20__20__20__20__20__20__20_Based_20_on_20_the_20_Data_20_Use_20_Ontology_20__3a__20_see_20_http_3a__2f__2f_www_2e_obofoundry_2e_org_2f_ontology_2f_duo_2e_html

which is due to the same description being used on different objects, re-defining the arvo type. This change renames the arvo type from the description to: <OBJECT_NAME>_<ATTRIBUTE_NAME>_anon_enum, which is globally unique thus avoiding the exception in arvo. 

This zip contains the yaml definition of a schema causing the bug in current main. 
[yaml.zip](https://github.com/user-attachments/files/17538293/yaml.zip)

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
